### PR TITLE
🐛 공고 상세 페이지 상시 채용 시 뱃지 제거, VC 추천 이유 제거, 반응형 수정

### DIFF
--- a/src/feature/post/ui/detail/PostDetailView.tsx
+++ b/src/feature/post/ui/detail/PostDetailView.tsx
@@ -178,9 +178,8 @@ export const PostDetailView = ({ postId }: { postId: string }) => {
             <span>채용 마감일</span>
             <div className="flex items-center gap-4">
               <span>
-                {position.employmentEndDate !== null
-                  ? formatIsoToDate(position.employmentEndDate)
-                  : '상시 채용'}
+                {position.employmentEndDate !== null &&
+                  formatIsoToDate(position.employmentEndDate)}
               </span>
               <Badge variant="primary">
                 {formatEmploymentState({
@@ -189,7 +188,7 @@ export const PostDetailView = ({ postId }: { postId: string }) => {
               </Badge>
             </div>
           </div>
-          <div className="flex flex-row gap-3 md:flex-col">
+          <div className="flex flex-row flex-wrap gap-3 md:flex-col">
             {role !== 'COMPANY' && (
               <div className="flex flex-col gap-3">
                 <Button
@@ -367,13 +366,13 @@ export const PostDetailView = ({ postId }: { postId: string }) => {
               company.vcRecommendation !== undefined && (
                 <section className="flex flex-col gap-3">
                   <span className="text-lg font-semibold text-grey-800">
-                    VC 추천 이유
+                    추천 VC
                   </span>
                   <p
                     data-color-mode="light"
                     className="flex rounded-md border p-4"
                   >
-                    {company.vcRecommendation}
+                    {company.vcName}
                   </p>
                 </section>
               )}


### PR DESCRIPTION
### 📝 작업 내용

- 공고 상세 페이지에서 상시 채용 하나만 표시
- 공고 상세 페이지에서 추천 VC 이름만 표기
- 공고 상세 페이지 모바일 반응형 깨짐 수정

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
