### PR TITLE
🐛  회사 직군명 길어진 상황 버그 개선

### DIFF
--- a/src/feature/post/ui/detail/PostDetailView.tsx
+++ b/src/feature/post/ui/detail/PostDetailView.tsx
@@ -134,6 +134,7 @@ export const PostDetailView = ({ postId }: { postId: string }) => {
               <div className="content-center">
                 {isBookmarked ? (
                   <button
+                    className="h-[48px] w-[48px]"
                     disabled={isPending}
                     onClick={(e) => {
                       e.stopPropagation();
@@ -144,6 +145,7 @@ export const PostDetailView = ({ postId }: { postId: string }) => {
                   </button>
                 ) : (
                   <button
+                    className="h-[48px] w-[48px]"
                     disabled={isPending}
                     onClick={(e) => {
                       e.stopPropagation();

--- a/src/feature/post/ui/mypage/applicant/BookmarkListView.tsx
+++ b/src/feature/post/ui/mypage/applicant/BookmarkListView.tsx
@@ -44,7 +44,9 @@ export const BookmarkListView = () => {
         >
           <div className="flex flex-1 items-center gap-4">
             <img src={ICON_SRC.BOOKMARK.SELECTED} />
-            <span className="truncate font-semibold">{post.positionTitle}</span>
+            <span className="max-w-[200px] truncate font-semibold">
+              {post.positionTitle}
+            </span>
           </div>
 
           <div className="flex items-center gap-4">


### PR DESCRIPTION
### 📝 작업 내용

- 회사 공고명이 길어진 상황에서의 버그 해결

1.  커피챗 리스트에서 스타일 영역 벗어나는 문제 truncate (...으로 대체)하여 해결
2. 공고 상세 페이지에서 북마크가 찌뿌되는 문제 북마크 figma 스펙에 맞게 사이즈 고정시켜 해결

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
