### PR TITLE
🐛  공고 생성 페이지에서 인원에 대한 안내 추가

### DIFF
--- a/src/feature/post/presentation/postFormPresentation.ts
+++ b/src/feature/post/presentation/postFormPresentation.ts
@@ -125,7 +125,8 @@ export const postFormPresentation: PostFormPresentation = {
           isError:
             headcount.value === '' ||
             isNaN(Number(headcount.value)) ||
-            Number(headcount.value) < 0,
+            Number(headcount.value) < 0 ||
+            Number(headcount.value) > 9999,
           value: Number(headcount.value),
         },
         salary: {

--- a/src/feature/post/ui/detail/PostDetailView.tsx
+++ b/src/feature/post/ui/detail/PostDetailView.tsx
@@ -128,7 +128,7 @@ export const PostDetailView = ({ postId }: { postId: string }) => {
             />
             <span className="text-lg font-semibold">{company.companyName}</span>
           </div>
-          <div className="flex w-full justify-between">
+          <div className="flex w-full items-center justify-between">
             <span className="text-4xl font-bold">{position.positionTitle}</span>
             {role !== 'COMPANY' && (
               <div className="content-center">

--- a/src/feature/post/ui/form/CreatePostForm.tsx
+++ b/src/feature/post/ui/form/CreatePostForm.tsx
@@ -155,7 +155,7 @@ export const CreatePostForm = ({ companyId }: { companyId: string }) => {
               isPending={isPending}
               isSubmit={isSubmit}
               isSubmitError={formStates.headcount.isError}
-              errorMessage={'모집 인원은 0 또는 양의 정수여야 합니다.'}
+              errorMessage={'0 또는 9,999 이하의 정수여야 합니다.'}
               infoMessage="0명일 경우 '0'을 작성해주세요."
               placeholder="모집 인원 수"
               required={true}


### PR DESCRIPTION
### 📝 작업 내용

- 공고 생성 페이지에서 인원에 대한 안내를 추가했습니다

### 📸 스크린샷 (선택)
<img width="707" alt="Screenshot 2025-05-10 at 12 58 37 AM" src="https://github.com/user-attachments/assets/29a81a02-9bef-49d4-a947-dcafc7ce3dc7" />

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
