### PR TITLE
🐛 다른 인풋 작성 시에 마크다운 에디터에 포커스 잡히는 버그 픽스

### DIFF
--- a/src/components/field/MarkdownEditorField.tsx
+++ b/src/components/field/MarkdownEditorField.tsx
@@ -1,7 +1,7 @@
 import '@toast-ui/editor/dist/toastui-editor.css';
 
 import { Editor, Viewer } from '@toast-ui/react-editor';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { LabelContainer } from '@/components/label/LabelContainer';
 import {
@@ -36,6 +36,7 @@ export const MarkdownEditorField = ({
   maxLength,
 }: MarkdownEditorFieldProps) => {
   const editorRef = useRef<Editor>(null);
+  const [isFocus, setIsFocus] = useState(false);
 
   const handleChange = () => {
     if (editorRef.current !== null) {
@@ -48,11 +49,11 @@ export const MarkdownEditorField = ({
   useEffect(() => {
     if (editorRef.current !== null) {
       const editorInstance = editorRef.current.getInstance();
-      if (input.value.length === 0) {
+      if (isFocus && input.value.length === 0) {
         editorInstance.setMarkdown('');
       }
     }
-  }, [input]);
+  }, [input, isFocus]);
 
   const toolbarItems = [
     ['heading', 'bold', 'italic', 'strike'],
@@ -74,6 +75,14 @@ export const MarkdownEditorField = ({
         usageStatistics={false}
         useCommandShortcut={true}
         onChange={handleChange}
+        events={{
+          focus: () => {
+            setIsFocus(true);
+          },
+          blur: () => {
+            setIsFocus(false);
+          },
+        }}
         autofocus={false}
         hideModeSwitch={true}
         ref={editorRef}


### PR DESCRIPTION
### 📝 작업 내용

- 마크다운이 비어있을 때에 다른 인풋을 작성하면 마크다운 에디터로 포커스가 이동하는 버그를 수정하였습니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
