### PR TITLE
🐛 escape html 디코딩이 모든 api에 공통적으로 일어나도록 수정

### DIFF
--- a/src/api/apis/utils/decodeHtml.ts
+++ b/src/api/apis/utils/decodeHtml.ts
@@ -1,0 +1,38 @@
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+export const decodeHtmlStrings = (
+  input: Record<string, unknown> | undefined,
+  recursive: boolean = true,
+) => {
+  const decodeHtml = (html: string): string => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    return doc.body.textContent ?? html;
+  };
+
+  if (input === undefined) {
+    return input;
+  }
+
+  if (isRecord(input)) {
+    const result: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(input)) {
+      if (typeof value === 'string') {
+        result[key] = decodeHtml(value);
+      } else if (recursive && isRecord(value)) {
+        result[key] = decodeHtmlStrings(value, true);
+      } else if (recursive && Array.isArray(value)) {
+        result[key] = value.map((item: unknown) =>
+          isRecord(item) ? decodeHtmlStrings(item, true) : item,
+        );
+      } else {
+        result[key] = value;
+      }
+    }
+
+    return result;
+  }
+};

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,5 @@
 import { getExternalServerApis, getLocalServerApis } from '@/api/apis';
+import { decodeHtmlStrings } from '@/api/apis/utils/decodeHtml';
 import type {
   ErrorResponse,
   ExternalCallParams,
@@ -39,7 +40,7 @@ export const implApi = ({ externalCall }: ImplApiProps) => {
       credentials: 'include',
     });
 
-    return response as R;
+    return decodeHtmlStrings(response) as R;
   };
 
   const callWithToken = <R extends ResponseNecessary>(

--- a/src/feature/post/ui/form/fields/EmploymentEndDateField.tsx
+++ b/src/feature/post/ui/form/fields/EmploymentEndDateField.tsx
@@ -39,7 +39,6 @@ export const EmploymentEndDateField = ({
   infoMessage,
   required,
 }: EmploymentEndDateField) => {
-  console.log(showFilter);
   return (
     <LabelContainer label={label} required={required}>
       <div className="relative">


### PR DESCRIPTION
### 📝 작업 내용

- escape html의 디코딩을 모든 api에 대해 수행하도록 수정하였습니다.

### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/cc7f422e-3fdc-4de0-a902-11dc046f86db)


### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
