### PR TITLE
💄 모집 인원, 월급 정보 공고 페이지 상단에 표기

### DIFF
--- a/src/feature/post/ui/detail/PostDetailView.tsx
+++ b/src/feature/post/ui/detail/PostDetailView.tsx
@@ -246,7 +246,30 @@ export const PostDetailView = ({ postId }: { postId: string }) => {
 
         {/* 회사 소개 */}
         <div className="flex w-full flex-col gap-4 md:max-w-[580px]">
-          <p className="text-xl font-semibold">회사 소개</p>
+          {/* 상세 공고 글 */}
+          <section className="flex w-full flex-col gap-[30px] md:max-w-[580px]">
+            <div className="flex flex-col gap-4 rounded-lg bg-grey-50 px-[34px] py-[24px]">
+              <div className="flex items-center gap-2">
+                <img src={ICON_SRC.PERSON} />
+                <span>
+                  {formatMinorJobToLabel(position.positionType)}{' '}
+                  {position.headCount}명
+                </span>
+              </div>
+              <div className="flex flex-1 gap-4">
+                <span className="text-grey-700">월급</span>
+                {position.salary == null ? (
+                  <span>추후 협의</span>
+                ) : (
+                  <span>{position.salary} 만원</span>
+                )}
+              </div>
+            </div>
+          </section>
+
+          <SeperatorLine className="md:max-w-[580px]" />
+
+          <p className="text-2xl font-semibold">회사 소개</p>
           {/* 회사 설명 카드 */}
           <section className="flex flex-col gap-4 rounded-lg bg-grey-50 px-[34px] py-[24px]">
             <div className="flex flex-col gap-4 md:flex-row md:gap-[68px]">
@@ -376,36 +399,16 @@ export const PostDetailView = ({ postId }: { postId: string }) => {
                   </p>
                 </section>
               )}
+
+            <SeperatorLine className="md:max-w-[580px]" />
+
+            <span className="text-2xl font-bold">상세 공고 글</span>
+            <div className="flex rounded-md border">
+              <MarkdownPreview content={position.detail} />
+            </div>
           </div>
         </div>
       </div>
-
-      <SeperatorLine className="md:max-w-[580px]" />
-
-      {/* 상세 공고 글 */}
-      <section className="flex w-full flex-col gap-[30px] md:max-w-[580px]">
-        <span className="text-2xl font-bold">상세 공고 글</span>
-        <div className="flex flex-col gap-4 rounded-lg bg-grey-50 px-[34px] py-[24px]">
-          <div className="flex items-center gap-2">
-            <img src={ICON_SRC.PERSON} />
-            <span>
-              {formatMinorJobToLabel(position.positionType)}{' '}
-              {position.headCount}명
-            </span>
-          </div>
-          <div className="flex flex-1 gap-4">
-            <span className="text-grey-700">월급</span>
-            {position.salary == null ? (
-              <span>추후 협의</span>
-            ) : (
-              <span>{position.salary} 만원</span>
-            )}
-          </div>
-        </div>
-        <div className="flex rounded-md border">
-          <MarkdownPreview content={position.detail} />
-        </div>
-      </section>
 
       {showModal === 'BOOKMARK' && (
         <SignInForBookmarkModal onClose={closeModal} />


### PR DESCRIPTION
### 📝 작업 내용

- 모집 인원, 월급 정보를 공고 상세 페이지 하단에서 상단으로 옮겼습니다
- 공고 상세 글은 그대로 하단에 위치합니다

### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/c78e1362-1d73-4b12-b9a5-6585997ef6f9)


### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
